### PR TITLE
Fixes for choosing files from search results

### DIFF
--- a/filebrowser/base.py
+++ b/filebrowser/base.py
@@ -265,6 +265,10 @@ class FileObject():
         "path relative to DIRECTORY"
         return path_strip(self.path, self.site.directory)
     path_relative_directory = property(_path_relative_directory)
+
+    def _dir(self):
+        return os.path.dirname(self.path_relative_directory)
+    dir = property(_dir)
     
     def _url(self):
         return self.site.storage.url(self.path)

--- a/filebrowser/templates/filebrowser/include/filelisting.html
+++ b/filebrowser/templates/filebrowser/include/filelisting.html
@@ -23,7 +23,7 @@
                             <ul class="pulldown-versions">
                                 {% for version in settings_var.ADMIN_VERSIONS %}
                                     {% version_setting version %}
-                                    <li{% if forloop.last %} class="last"{% endif %}><a href="{% url filebrowser:fb_version %}{% query_string '' 'filename' %}&amp;filename={{ fileobject.filename|urlencode }}&amp;version={{ version }}" title="">{{ version_setting.verbose_name }}</a></li>
+                                    <li{% if forloop.last %} class="last"{% endif %}><a href="{% url filebrowser:fb_version %}{% query_string '' 'filename, dir' %}&amp;dir={{ fileobject.dir|urlencode }}&amp;filename={{ fileobject.filename|urlencode }}&amp;version={{ version }}" title="">{{ version_setting.verbose_name }}</a></li>
                                 {% endfor %}
                             </ul>
                         </div>


### PR DESCRIPTION
Cherry pick cb55418831fa4e167c11a86dd170376a18bc978a from git://github.com/sehmaschine/django-filebrowser.git, which fixes  https://github.com/sehmaschine/django-filebrowser/issues/135

Add a fix for https://github.com/sehmaschine/django-filebrowser/issues/150
