### PR TITLE
Removed usage of deprecated model._meta.model_name.

### DIFF
--- a/filebrowser/admin.py
+++ b/filebrowser/admin.py
@@ -16,7 +16,7 @@ class FileBrowserAdmin(admin.ModelAdmin):
         return False
 
     def get_urls(self):
-        info = self.model._meta.app_label, self.model._meta.module_name
+        info = self.model._meta.app_label, self.model._meta.model_name
         return patterns('',
             url('^$', self.admin_site.admin_view(self.filebrowser_view), name='{0}_{1}_changelist'.format(*info)),
         )


### PR DESCRIPTION
`module_name` emits a warning with Django 1.7. Do you mind dropping 1.4/1.5 support or would you like conditional logic to keep support for those versions?
