### PR TITLE
Fix #7 Use `model._meta.model_name` if available else fallback to `module_name`

### DIFF
--- a/filebrowser/admin.py
+++ b/filebrowser/admin.py
@@ -16,7 +16,8 @@ class FileBrowserAdmin(admin.ModelAdmin):
         return False
 
     def get_urls(self):
-        info = self.model._meta.app_label, self.model._meta.module_name
+        opts = self.model._meta
+        info = opts.app_label, (opts.model_name if hasattr(opts, 'model_name') else opts.module_name)
         return patterns('',
             url('^$', self.admin_site.admin_view(self.filebrowser_view), name='{0}_{1}_changelist'.format(*info)),
         )


### PR DESCRIPTION
This will use `model._meta.model_name` from Django >= 1.6 and will fallback to `model._meta.modul_name` for Django < 1.6

This will fix https://github.com/smacker/django-filebrowser-no-grappelli/pull/7
