### PR TITLE
Add config for use admin_custom, not admin.sites.site of Django

### DIFF
--- a/filebrowser/settings.py
+++ b/filebrowser/settings.py
@@ -117,3 +117,20 @@ _('Image')
 _('Video')
 _('Document')
 _('Audio')
+
+
+# Overwrite admin_site.
+# Example: 
+# in file: apps.core.admin define this code.
+
+# from django.contrib import admin
+# class CustomAdmin(admin.AdminSite):
+#     site_header = site_title = 'Custom Admin'
+#     index_title = 'Custom Administration'
+
+# admin_general = CustomAdmin(name='admin_general')
+
+# In settings:
+# FILEBROWSER_CUSTOM_ADMIN = 'apps.core.admin.admin_general'
+
+ADMIN_CUSTOM = getattr(settings, 'FILEBROWSER_CUSTOM_ADMIN', None)

--- a/filebrowser/sites.py
+++ b/filebrowser/sites.py
@@ -9,6 +9,7 @@ from django import forms
 from django import VERSION as DJANGO_VERSION
 from django.contrib import messages
 from django.contrib.admin.sites import site as admin_site
+from django.utils.module_loading import import_string 
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.files.storage import DefaultStorage, default_storage, FileSystemStorage
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
@@ -29,9 +30,16 @@ from filebrowser.decorators import path_exists, file_exists
 from filebrowser.storage import FileSystemStorageMixin
 from filebrowser.templatetags.fb_tags import query_helper
 from filebrowser.utils import convert_filename
-from filebrowser.settings import (DIRECTORY, EXTENSIONS, SELECT_FORMATS, ADMIN_VERSIONS, ADMIN_THUMBNAIL, MAX_UPLOAD_SIZE, NORMALIZE_FILENAME,
-                                  CONVERT_FILENAME, SEARCH_TRAVERSE, EXCLUDE, VERSIONS, VERSIONS_BASEDIR, EXTENSION_LIST, DEFAULT_SORTING_BY, DEFAULT_SORTING_ORDER,
-                                  LIST_PER_PAGE, OVERWRITE_EXISTING, DEFAULT_PERMISSIONS, UPLOAD_TEMPDIR)
+from filebrowser.settings import (DIRECTORY, EXTENSIONS, SELECT_FORMATS, ADMIN_VERSIONS, ADMIN_THUMBNAIL, 
+    MAX_UPLOAD_SIZE, NORMALIZE_FILENAME, CONVERT_FILENAME, SEARCH_TRAVERSE, EXCLUDE, VERSIONS, 
+    VERSIONS_BASEDIR, EXTENSION_LIST, DEFAULT_SORTING_BY, DEFAULT_SORTING_ORDER, LIST_PER_PAGE,
+    OVERWRITE_EXISTING, DEFAULT_PERMISSIONS, UPLOAD_TEMPDIR, ADMIN_CUSTOM
+)
+
+
+
+# This use admin_custom and not admin.sites.site of Django.
+admin_site = import_string(ADMIN_CUSTOM) if ADMIN_CUSTOM else admin_site
 
 
 # Add some required methods to FileSystemStorage


### PR DESCRIPTION
La idea de ésta mejora es que se pueda utilizar un admin personalizado y no el que viene por defecto con django.