### PR TITLE
replace _get_val_from_obj with value_from_object

### DIFF
--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -116,7 +116,7 @@ class FileBrowseField(CharField):
         return value.path
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         if not value:
             return value
         return value.path
@@ -254,7 +254,7 @@ class FileBrowseUploadField(CharField):
         return value.path
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         if not value:
             return value
         return value.path


### PR DESCRIPTION
This fixes an issue with Django 2.0 removing _get_val_from_obj and replaces it with value_form_object.

May break Django < 2.0