### PR TITLE
Fixed issue with no renderer attribute in Django 2.1

### DIFF
--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -36,7 +36,7 @@ class FileBrowseWidget(Input):
             self.attrs = {}
         super(FileBrowseWidget, self).__init__(attrs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         url = reverse(self.site.name + ":fb_browse")
         if value is None:
             value = ""
@@ -164,7 +164,7 @@ class FileBrowseUploadWidget(Input):
             self.attrs = {}
         super(FileBrowseUploadWidget, self).__init__(attrs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         url = reverse(self.site.name + ":fb_browse")
         if value is None:
             value = ""


### PR DESCRIPTION
Django 2.1 removed support for Widget.render() methods without the renderer argument: https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1