### PR TITLE
replace TEMPLATE_DEBUG in templatetag fb_version

### DIFF
--- a/filebrowser/static/filebrowser/img/test_not_an_image.jpg
+++ b/filebrowser/static/filebrowser/img/test_not_an_image.jpg
@@ -1,0 +1,1 @@
+not an image

--- a/filebrowser/templatetags/fb_versions.py
+++ b/filebrowser/templatetags/fb_versions.py
@@ -45,7 +45,7 @@ class VersionNode(Node):
             else:
                 return version.url
         except Exception:
-            if settings.TEMPLATE_DEBUG:
+            if context.template.engine.debug:
                 raise
             if self.var_name:
                 context[self.var_name] = ""

--- a/tests/base.py
+++ b/tests/base.py
@@ -40,8 +40,10 @@ class FilebrowserTestCase(TestCase):
 
         self.STATIC_IMG_PATH = os.path.join(settings.BASE_DIR, 'filebrowser', "static", "filebrowser", "img", "testimage.jpg")
         self.STATIC_IMG_BAD_NAME_PATH = os.path.join(settings.BASE_DIR, 'filebrowser', "static", "filebrowser", "img", "TEST_IMAGE_000.jpg")
+        self.STATIC_IMG_BAD_PATH = os.path.join(settings.BASE_DIR, 'filebrowser', "static", "filebrowser", "img", "test_not_an_image.jpg")
 
         self.F_IMAGE = FileObject(os.path.join(DIRECTORY, 'folder', "testimage.jpg"), site=site)
+        self.F_IMAGE_BAD = FileObject(os.path.join(DIRECTORY, 'folder', "test_not_an_image.jpg"), site=site)
         self.F_MISSING = FileObject(os.path.join(DIRECTORY, 'folder', "missing.jpg"), site=site)
         self.F_FOLDER = FileObject(os.path.join(DIRECTORY, 'folder'), site=site)
         self.F_SUBFOLDER = FileObject(os.path.join(DIRECTORY, 'folder', 'subfolder'), site=site)

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -361,6 +361,7 @@ class VersionObjectTemplateTagTests(TestCase):
     def setUp(self):
         super(VersionObjectTemplateTagTests, self).setUp()
         shutil.copy(self.STATIC_IMG_PATH, self.FOLDER_PATH)
+        shutil.copy(self.STATIC_IMG_BAD_PATH, self.FOLDER_PATH)
 
         os.makedirs(self.PLACEHOLDER_PATH)
         shutil.copy(self.STATIC_IMG_PATH, self.PLACEHOLDER_PATH)
@@ -407,6 +408,13 @@ class VersionObjectTemplateTagTests(TestCase):
         r = t.render(c)
         self.assertEqual(c["version_large"].url, os.path.join(settings.MEDIA_URL, ""))
         self.assertEqual(r, os.path.join(settings.MEDIA_URL, ""))
+
+    def test_jpg_not_an_image(self):
+        t = Template('{% load fb_versions %}{% version obj "large" as version_large %}{{ version_large.url }}')
+        c = Context({"obj": self.F_IMAGE_BAD})
+        r = t.render(c)
+        self.assertEqual(c["version_large"], "")
+        self.assertEqual(r, "")
 
     @patch('filebrowser.templatetags.fb_versions.SHOW_PLACEHOLDER', True)
     @patch('filebrowser.templatetags.fb_versions.FORCE_PLACEHOLDER', True)


### PR DESCRIPTION
This is to replace TEMPLATE_DEBUG in templatetag fb_version, as TEMPLATE_DEBUG is removed in Django 1.10

The test case comes from use case that, if a user accidentally upload a non-image file with an image extension, then it should not throw an 50x error in the filebrowser admin listing when trying to list the erroneous file.

Let me know of your thoughts.  Many thanks!