### PR TITLE
Django 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,6 @@ script:
 matrix:
   include:
     - python: "2.7"
-      env: TOXENV=py27-django18
-    - python: "3.4"
-      env: TOXENV=py34-django18
-    - python: "3.5"
-      env: TOXENV=py35-django18
-    - python: "3.6"
-      env: TOXENV=py36-django18
-    - python: "2.7"
       env: TOXENV=py27-django111
     - python: "3.4"
       env: TOXENV=py34-django111
@@ -22,12 +14,18 @@ matrix:
       env: TOXENV=py35-django111
     - python: "3.6"
       env: TOXENV=py36-django111
-    - python: "3.4"
-      env: TOXENV=py34-django20
     - python: "3.5"
-      env: TOXENV=py35-django20
+      env: TOXENV=py35-django22
     - python: "3.6"
-      env: TOXENV=py36-django20
+      env: TOXENV=py36-django22
+    - python: "3.7"
+      env: TOXENV=py37-django30
+    - python: "3.6"
+      env: TOXENV=py36-django30
+    - python: "3.7"
+      env: TOXENV=py36-django30
+    - python: "3.8"
+      env: TOXENV=py38-django30
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - python: "3.6"
       env: TOXENV=py36-django30
     - python: "3.7"
-      env: TOXENV=py36-django30
+      env: TOXENV=py37-django30
     - python: "3.8"
       env: TOXENV=py38-django30
 branches:

--- a/filebrowser/base.py
+++ b/filebrowser/base.py
@@ -8,9 +8,9 @@ import tempfile
 import time
 
 from django.core.files import File
-from django.utils.encoding import python_2_unicode_compatible, force_text
-from django.utils.six import string_types
+from django.utils.encoding import force_text
 from django.utils.functional import cached_property
+from six import python_2_unicode_compatible, string_types
 
 from filebrowser.settings import EXTENSIONS, VERSIONS, ADMIN_VERSIONS, VERSIONS_BASEDIR, VERSION_QUALITY, STRICT_PIL, IMAGE_MAXBLOCK, DEFAULT_PERMISSIONS
 from filebrowser.utils import path_strip, process_image

--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -9,8 +9,8 @@ except ImportError:
 from django.db.models.fields import CharField
 from django.forms.widgets import Input
 from django.template.loader import render_to_string
+from django.templatetags.static import static
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.admin.options import FORMFIELD_FOR_DBFIELD_DEFAULTS
 from six import string_types
 

--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -1,8 +1,6 @@
 # coding: utf-8
 import os
 
-from django.utils.six import string_types
-
 from django import forms
 try:
     from django.urls import reverse
@@ -14,6 +12,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.admin.templatetags.admin_static import static
 from django.contrib.admin.options import FORMFIELD_FOR_DBFIELD_DEFAULTS
+from six import string_types
 
 from filebrowser.base import FileObject
 from filebrowser.settings import ADMIN_THUMBNAIL, EXTENSIONS, UPLOAD_TEMPDIR

--- a/filebrowser/management/commands/fb_version_generate.py
+++ b/filebrowser/management/commands/fb_version_generate.py
@@ -5,7 +5,7 @@ import re
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.six.moves import input
+from six.moves import input
 
 from filebrowser.base import FileListing
 from filebrowser.settings import EXTENSION_LIST, EXCLUDE, DIRECTORY, VERSIONS

--- a/filebrowser/management/commands/fb_version_remove.py
+++ b/filebrowser/management/commands/fb_version_remove.py
@@ -5,7 +5,7 @@ import sys
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.six.moves import input
+from six.moves import input
 
 from filebrowser.settings import EXCLUDE, EXTENSIONS
 

--- a/filebrowser/namers.py
+++ b/filebrowser/namers.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import re
-from django.utils import six
+
+import six
 from django.utils.encoding import force_text
 from django.utils.module_loading import import_string
 

--- a/filebrowser/templates/filebrowser/createdir.html
+++ b/filebrowser/templates/filebrowser/createdir.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load admin_static i18n fb_tags fb_csrf fb_compat %}
+{% load static i18n fb_tags fb_csrf fb_compat %}
 
 <!-- STYLESHEETS -->
 {% block extrastyle %}

--- a/filebrowser/templates/filebrowser/delete_confirm.html
+++ b/filebrowser/templates/filebrowser/delete_confirm.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load admin_static i18n fb_tags fb_versions fb_compat %}
+{% load static i18n fb_tags fb_versions fb_compat %}
 
 <!-- BREADCRBUMBS -->
 {% block breadcrumbs %}{% include "filebrowser/include/breadcrumbs.html" %}{% endblock %}

--- a/filebrowser/templates/filebrowser/detail.html
+++ b/filebrowser/templates/filebrowser/detail.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load admin_static i18n fb_tags fb_versions fb_compat %}
+{% load static i18n fb_tags fb_versions fb_compat %}
 
 <!-- STYLESHEETS -->
 {% block extrastyle %}

--- a/filebrowser/templates/filebrowser/index.html
+++ b/filebrowser/templates/filebrowser/index.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load admin_static i18n fb_tags fb_pagination fb_compat %}
+{% load static i18n fb_tags fb_pagination fb_compat %}
 
 <!-- STYLESHEETS -->
 {% block extrastyle %}

--- a/filebrowser/templates/filebrowser/upload.html
+++ b/filebrowser/templates/filebrowser/upload.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load admin_static i18n l10n fb_tags fb_compat %}
+{% load static i18n l10n fb_tags fb_compat %}
 
 <!-- STYLESHEETS -->
 {% block extrastyle %}

--- a/filebrowser/templates/filebrowser/version.html
+++ b/filebrowser/templates/filebrowser/version.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load admin_static i18n fb_tags fb_versions fb_compat %}
+{% load static i18n fb_tags fb_versions fb_compat %}
 
 <!-- JAVASCRIPTS -->
 {% block extrahead %}

--- a/filebrowser/templatetags/fb_compat.py
+++ b/filebrowser/templatetags/fb_compat.py
@@ -2,7 +2,7 @@
 
 from django import VERSION as DJANGO_VERSION
 from django import template
-from django.contrib.admin.templatetags.admin_static import static
+from django.templatetags.static import static
 
 
 register = template.Library()

--- a/filebrowser/templatetags/fb_tags.py
+++ b/filebrowser/templatetags/fb_tags.py
@@ -1,8 +1,6 @@
 # coding: utf-8
 
-from django import VERSION as DJANGO_VERSION
 from django import template
-from django.contrib.admin.templatetags.admin_static import static
 from django.template import TemplateSyntaxError
 from django.utils.http import urlquote
 from django.utils.safestring import mark_safe

--- a/filebrowser/utils.py
+++ b/filebrowser/utils.py
@@ -5,7 +5,7 @@ import os
 import unicodedata
 import math
 
-from django.utils import six
+import six
 from django.utils.module_loading import import_string
 
 from filebrowser.settings import STRICT_PIL, NORMALIZE_FILENAME, CONVERT_FILENAME

--- a/runtests.py
+++ b/runtests.py
@@ -11,9 +11,6 @@ if __name__ == "__main__":
         django.setup()
 
     from django.conf import settings
-    # WTF??? Otherwise it doesn't work with Django 1.4
-    settings.DATABASES
-
     from django.test.utils import get_runner
 
     TestRunner = get_runner(settings)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 setup(
     name='django-filebrowser-no-grappelli',
     version='3.7.8',
@@ -28,12 +29,14 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     zip_safe=False,
+    install_requires=['six'],
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
-funcsigs==0.4
-mock==1.3.0
-pbr==1.8.0
-Pillow==2.9.0
+funcsigs==1.0.2
+mock==3.0.5
+pbr==5.4.4
+Pillow==6.2.1
 six==1.12.0
-wheel==0.24.0
+wheel==0.33.6

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,7 @@
 funcsigs==1.0.2
 mock==3.0.5
 pbr==5.4.4
-Pillow==6.2.1
+Pillow==5.4.1; python_version < '3.5'
+Pillow==6.2.1; python_version >= '3.5'
 six==1.12.0
 wheel==0.33.6

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,4 +2,5 @@ funcsigs==0.4
 mock==1.3.0
 pbr==1.8.0
 Pillow==2.9.0
+six==1.12.0
 wheel==0.24.0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,7 +6,7 @@ import shutil
 
 from django.conf import settings
 from django.core.management import call_command
-from django.utils.six import StringIO
+from six import StringIO
 
 from filebrowser.settings import DIRECTORY
 from tests.base import FilebrowserTestCase as TestCase

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -2,7 +2,7 @@
 
 from tests import FilebrowserTestCase as TestCase
 
-from django.utils.six import string_types
+from six import string_types
 
 from filebrowser.base import FileObject
 from filebrowser.fields import FileBrowseField

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -157,54 +157,54 @@ class UploadFileViewTests(TestCase):
     @patch('filebrowser.sites.OVERWRITE_EXISTING', True)
     def test_overwrite_existing_true(self):
         shutil.copy(self.STATIC_IMG_PATH, self.SUBFOLDER_PATH)
-        self.assertEqual(site.storage.listdir(self.F_SUBFOLDER), ([], [u'testimage.jpg']))
+        self.assertEqual(site.storage.listdir(self.F_SUBFOLDER.path), ([], [u'testimage.jpg']))
 
         url = '?'.join([self.url, urlencode({'folder': self.F_SUBFOLDER.path_relative_directory})])
 
         with open(self.STATIC_IMG_PATH, "rb") as f:
             self.client.post(url, data={'qqfile': 'testimage.jpg', 'file': f}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
-        self.assertEqual(site.storage.listdir(self.F_SUBFOLDER), ([], [u'testimage.jpg']))
+        self.assertEqual(site.storage.listdir(self.F_SUBFOLDER.path), ([], [u'testimage.jpg']))
 
     @patch('filebrowser.sites.OVERWRITE_EXISTING', False)
     def test_overwrite_existing_false(self):
         shutil.copy(self.STATIC_IMG_PATH, self.SUBFOLDER_PATH)
-        self.assertEqual(site.storage.listdir(self.F_SUBFOLDER), ([], [u'testimage.jpg']))
+        self.assertEqual(site.storage.listdir(self.F_SUBFOLDER.path), ([], [u'testimage.jpg']))
 
         url = '?'.join([self.url, urlencode({'folder': self.F_SUBFOLDER.path_relative_directory})])
 
         with open(self.STATIC_IMG_PATH, "rb") as f:
             self.client.post(url, data={'qqfile': 'testimage.jpg', 'file': f}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
-        self.assertEqual(len(site.storage.listdir(self.F_SUBFOLDER)[1]), 2)
+        self.assertEqual(len(site.storage.listdir(self.F_SUBFOLDER.path)[1]), 2)
 
     @patch('filebrowser.utils.CONVERT_FILENAME', False)
     @patch('filebrowser.utils.NORMALIZE_FILENAME', False)
     def test_convert_false_normalize_false(self):
         with open(self.STATIC_IMG_BAD_NAME_PATH, "rb") as f:
             self.client.post(self.url_bad_name, data={'qqfile': 'TEST_IMAGE_000.jpg', 'file': f}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-            self.assertEqual(site.storage.listdir(self.F_SUBFOLDER), ([], [u'TEST_IMAGE_000.jpg']))
+            self.assertEqual(site.storage.listdir(self.F_SUBFOLDER.path), ([], [u'TEST_IMAGE_000.jpg']))
 
     @patch('filebrowser.utils.CONVERT_FILENAME', True)
     @patch('filebrowser.utils.NORMALIZE_FILENAME', False)
     def test_convert_true_normalize_false(self):
         with open(self.STATIC_IMG_BAD_NAME_PATH, "rb") as f:
             self.client.post(self.url_bad_name, data={'qqfile': 'TEST_IMAGE_000.jpg', 'file': f}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-            self.assertEqual(site.storage.listdir(self.F_SUBFOLDER), ([], [u'test_image_000.jpg']))
+            self.assertEqual(site.storage.listdir(self.F_SUBFOLDER.path), ([], [u'test_image_000.jpg']))
 
     @patch('filebrowser.utils.CONVERT_FILENAME', False)
     @patch('filebrowser.utils.NORMALIZE_FILENAME', True)
     def test_convert_false_normalize_true(self):
         with open(self.STATIC_IMG_BAD_NAME_PATH, "rb") as f:
             self.client.post(self.url_bad_name, data={'qqfile': 'TEST_IMAGE_000.jpg', 'file': f}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-            self.assertEqual(site.storage.listdir(self.F_SUBFOLDER), ([], [u'TEST_IMAGE_000.jpg']))
+            self.assertEqual(site.storage.listdir(self.F_SUBFOLDER.path), ([], [u'TEST_IMAGE_000.jpg']))
 
     @patch('filebrowser.utils.CONVERT_FILENAME', True)
     @patch('filebrowser.utils.NORMALIZE_FILENAME', True)
     def test_convert_true_normalize_true(self):
         with open(self.STATIC_IMG_BAD_NAME_PATH, "rb") as f:
             self.client.post(self.url_bad_name, data={'qqfile': 'TEST_IMAGE_000.jpg', 'file': f}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-            self.assertEqual(site.storage.listdir(self.F_SUBFOLDER), ([], [u'test_image_000.jpg']))
+            self.assertEqual(site.storage.listdir(self.F_SUBFOLDER.path), ([], [u'test_image_000.jpg']))
 
 
 class DetailViewTests(TestCase):

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -8,10 +8,7 @@ try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse
-try:
-    from django.utils.six.moves.urllib.parse import urlencode
-except ImportError:
-    from django.utils.http import urlencode
+from django.utils.http import urlencode
 from mock import patch
 
 from filebrowser.settings import VERSIONS, DEFAULT_PERMISSIONS

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py{27,34,35,36}-django1{8,11},py{34,35,36}-django20
+envlist = py{27,34,35,36}-django111,py{35,36,37}-django22,py{36,37,38}-django30
 
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
-    django18: Django>=1.8,<1.9
     django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
+    django22: Django>=2.2,<3.0
+    django30 Django>=3.0,<3.1
     -rtests/requirements.txt
     coverage
 commands = ./runtests.py {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ setenv =
 deps =
     django111: Django>=1.11,<2.0
     django22: Django>=2.2,<3.0
-    django30 Django>=3.0,<3.1
+    django30: Django>=3.0,<3.1
     -rtests/requirements.txt
     coverage
 commands = ./runtests.py {posargs}


### PR DESCRIPTION
Adds support for Django 3.0 by using `six` from it's own package rather than `django.utils.six` and by removing use of the deprecated `admin_static` alias to `static`.