### PR TITLE
Added DropBoxStorageMixin (partially supported)

### DIFF
--- a/filebrowser/base.py
+++ b/filebrowser/base.py
@@ -519,7 +519,7 @@ class FileObject():
         except IOError:
             version.save(tmpfile, format=Image.EXTENSION[ext.lower()], quality=VERSION_QUALITY)
         # remove old version, if any
-        if version_path != self.site.storage.get_available_name(version_path):
+        if self.site.storage.path(version_path) != self.site.storage.get_available_name(version_path):
             self.site.storage.delete(version_path)
         self.site.storage.save(version_path, tmpfile)
         # set permissions


### PR DESCRIPTION
**Example of usage:**

1. Define a custom storage class that will inherit from `django-storage's DropBoxStorage` and `filebrowser's DropBoxStorageMixin`
```
from filebrowser.storage import DropBoxStorageMixin
from storages.backends.dropbox import DropBoxStorage as BaseDropBoxStorage


class DropBoxStorage(BaseDropBoxStorage, DropBoxStorageMixin):

    def url(self, name):
        """
        It's needed to override this method, since the link
        returned by default expires after a few hours. Instead
        we need to use the shared link, which doesn't expire
        """
        shared_link = self.client.sharing_create_shared_link(self._full_path(name))
        return shared_link.url.replace("dl=0", "dl=1")

    def path(self, name):
        return self._full_path(name)

    def get_modified_time(self, name):
        """
        this method is used by filebrowser's browse view
        KNOWN_ISSUE: it breaks when name is a folder
        """
        metadata = self.client.files_get_metadata(self._full_path(name))
        modified_time = metadata.server_modified
        if settings.USE_TZ:
            modified_time = make_aware(modified_time)
        return modified_time
```

2. Set `DEFAULT_FILE_STORAGE` to the previous custom storage class


**Known limitations:**

- Create folder functionality doesn't work since method `get_modified_time` will fail when retrieving the server_modifed for a folder