### PR TITLE
Update fb_versions.py

### DIFF
--- a/filebrowser/templatetags/fb_versions.py
+++ b/filebrowser/templatetags/fb_versions.py
@@ -34,7 +34,10 @@ class VersionNode(Node):
             source = source.name
         else:  # string
             source = source
-        site = context.get('filebrowser_site', get_default_site())
+        if 'filebrowser_site' in context:
+            site = context['filebrowser_site']
+        else:
+            site = get_default_site()
         if FORCE_PLACEHOLDER or (SHOW_PLACEHOLDER and not site.storage.isfile(source)):
             source = PLACEHOLDER
         fileobject = FileObject(source, site=site)


### PR DESCRIPTION
If there are no FileBrowser sites registered inside urls.py with app_name = 'filebrowser', get_default_site() in the line site = context.get('filebrowser_site', get_default_site()) raises a KeyError beacause of https://github.com/sehmaschine/django-filebrowser/blob/751f46ab985f3224f94f9450d9a037772221e33c/filebrowser/sites.py#L88, even if context contains the 'filebrowser' key. I changed the implementation of the render method so that get_default_site() only is evaluated if context does not contain the 'filebrowser' key.